### PR TITLE
Optimized Import Blogs Action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ group :test do
 end
 gem 'devise'
 gem 'pagy'
+gem 'activerecord-import'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,6 +54,8 @@ GEM
     activerecord (7.0.8)
       activemodel (= 7.0.8)
       activesupport (= 7.0.8)
+    activerecord-import (1.8.1)
+      activerecord (>= 4.2)
     activestorage (7.0.8)
       actionpack (= 7.0.8)
       activejob (= 7.0.8)
@@ -135,6 +137,8 @@ GEM
     net-smtp (0.4.0.1)
       net-protocol
     nio4r (2.7.0)
+    nokogiri (1.16.2-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.2-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -228,9 +232,11 @@ GEM
     zeitwerk (2.6.13)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
+  activerecord-import
   bootsnap
   capybara
   cssbundling-rails

--- a/app/controllers/blogs_controller.rb
+++ b/app/controllers/blogs_controller.rb
@@ -63,14 +63,8 @@ class BlogsController < ApplicationController
 
   def import
     file = params[:attachment]
-    data = CSV.parse(file.to_io, headers: true, encoding: 'utf8')
-    # Start code to handle CSV data
-    ActiveRecord::Base.transaction do
-      data.each do |row|
-        current_user.blogs.create!(row.to_h)
-      end
-    end
-    # End code to handle CSV data
+    # Moved the import logic to a separate service
+    ImportBlogsService.new(current_user, file).import
     redirect_to blogs_path
   end
 

--- a/app/services/import_blogs_service.rb
+++ b/app/services/import_blogs_service.rb
@@ -1,0 +1,32 @@
+require 'csv'
+
+class ImportBlogsService
+  def initialize(user, file, batch_size: 1000)
+    @user = user
+    @file = file
+    @batch_size = batch_size
+    @rows = []
+  end
+
+  def import
+    parse_csv
+    insert_rows(@rows) if @rows.any?
+  end
+
+  private
+
+  def parse_csv
+    CSV.foreach(@file.to_io, headers: true, encoding: 'utf8') do |row|
+      @rows << @user.blogs.new(row.to_h)
+
+      if @rows.size >= @batch_size
+        insert_rows(@rows)
+        @rows.clear
+      end
+    end
+  end
+
+  def insert_rows(rows)
+    Blog.import(rows)
+  end
+end


### PR DESCRIPTION
# Changes Made
- created a separate service import_blogs_service to keep blogs_controller clean
- used batch processing for the csv data to reduce memory usage
- added activerecord-import gem to create blogs in bulk which caused less database queries than creating individual blog
- added batch-level transactions to reduce memory consumption and avoid database locking issues

# Optimization Details
- Before optimization, the import action took around 190 seconds to execute csv of 100k records.
<img width="580" alt="Screenshot 2024-10-31 at 12 51 22 AM" src="https://github.com/user-attachments/assets/b4f66bf1-460b-4d15-8b39-03cebd3884df">

- After optimization, the import action took around 39 seconds to execute csv of 100k records.
<img width="582" alt="Screenshot 2024-10-31 at 12 56 44 AM" src="https://github.com/user-attachments/assets/39ed94c9-84bd-44f5-bf6e-a0d2cdcfbee3">

# Result
- The optimization made approximately 80% improvement in execution time.

# Assumptions
- Multiple blogs with the same title are allowed (duplicate blogs). 